### PR TITLE
Fixing broken link to SampleSource/Testing folder

### DIFF
--- a/src/Testing/AggregateSource.Testing/README.md
+++ b/src/Testing/AggregateSource.Testing/README.md
@@ -80,5 +80,5 @@ new QueryScenarioFor<TicketSale>(TicketSale.Factory).
 
 Mind that the Assert* methods are **not** in the box (applies to collaborating aggregates only). It's an integration point between the test specifications and your testing framework of choice. Leverage its asserts to execute the specification.
 
-Looking for an example? Head on over to the Testing folder of the [SampleSource](../SampleSource/ "Sample source") project.
+Looking for an example? Head on over to the Testing folder of the [SampleSource](../../SampleSource/Testing "Sample source") project.
 The principles discussed here are easily applicable to other frameworks and libraries. Feel free to steal ...


### PR DESCRIPTION
Link to Testing/SampleSource was broken -- correct location seems to be SampleSource/Testing
